### PR TITLE
Use production mode for React that strips out all the warnings

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 var path = require("path");
+var webpack = require('webpack');
 
 module.exports = {
     entry: {
@@ -13,5 +14,12 @@ module.exports = {
         loaders: [
             { test: /\.js$/, exclude: /node_modules/, loader: "babel" },
         ]
-    }
+    },
+    plugins: [
+      new webpack.DefinePlugin({
+        'process.env': {
+          'NODE_ENV': JSON.stringify('production')
+        }
+      })
+    ],
 }


### PR DESCRIPTION
This benchmark is using the dev mode of React which enables a lot of developer warnings and is not meant to be used in production because it is way slower. This pull request enables production mode and the perf is totally different.

I bumped the number of games to 500 in both React and Vue and this is what the traces look like:

React:
<img width="1415" alt="screen shot 2016-05-24 at 10 29 12 am" src="https://cloud.githubusercontent.com/assets/197597/15513750/d5f47670-219a-11e6-8b35-0f4f6a8036f5.png">

Vue:
<img width="1415" alt="screen shot 2016-05-24 at 10 29 16 am" src="https://cloud.githubusercontent.com/assets/197597/15513755/da883014-219a-11e6-860c-f71387716cc9.png">
