### PR TITLE
Fix React warning

### DIFF
--- a/src/react.js
+++ b/src/react.js
@@ -56,11 +56,11 @@ class Games extends React.Component {
 }
 
 class Game extends React.Component {
-    
+
     shouldComponentUpdate(nextProps){
         return nextProps.game !== this.props.game;
     }
-    
+
     render() {
         const game = this.props.game;
         const score = `${game.getIn(["score", "home"])}-${game.getIn(["score", "away"])}`;
@@ -102,7 +102,7 @@ class Player extends React.Component {
             <td>
                 <div className="player">
                     <p className="player__name">
-                        <div>{player.get("name") }</div>
+                        <span>{player.get("name") }</span>
                         <span className="u-small">
                             {player.get("invitedNextWeek") ? "Not coming again" : "Doing well"}
                         </span>


### PR DESCRIPTION
There's a warning in the dev version of React:

"Warning: validateDOMNesting(...): &lt;div> cannot appear as a descendant of &lt;p>. See Player > p > ... > div."

This means that the browser re-arranges the dom under you and is probably not something you want. I fixed it on both versions.